### PR TITLE
Resolved server connection issue by appending the port number to the URL configuration.

### DIFF
--- a/lib/core/http_client.dart
+++ b/lib/core/http_client.dart
@@ -27,6 +27,7 @@ class HttpBaseClient extends http.BaseClient {
       scheme: _baseUrl.scheme,
       host: _baseUrl.host,
       path: _baseUrl.path + url.path,
+      port: _baseUrl.port,
     );
   }
 


### PR DESCRIPTION
Resolved server connection issue by appending the port number to the URL configuration. This correction was necessary because the server was inaccessible due to the missing port in the URL, which caused connection failures.